### PR TITLE
adding windows support

### DIFF
--- a/.kitchen-vagrant.yml
+++ b/.kitchen-vagrant.yml
@@ -1,0 +1,26 @@
+driver_plugin: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+- name: windows-2012R2
+  driver_config:
+    box: mwrock/Windows2012R2
+  transport:
+    name: winrm
+
+- name: ubuntu-12.04
+  run_list:
+  - recipe[ubuntu]
+  driver_config:
+    box: hashicorp/precise64
+
+suites:
+- name: default
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[minecraft]
+  attributes:
+    minecraft:
+      accept_eula: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,7 @@ platforms:
 - name: centos-6.5
   run_list:
   - recipe[yum-epel]
+
 suites:
 - name: default
   run_list:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - cookbooks/**/*
     - tmp/**/*
     - vendor/**/*
+    - .kitchen/**/*
 
 AlignParameters:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Tested on chef 11
 * Debian 6+
 * Ubuntu 12.04+
 * Centos 6.4+
+* Windows 8/2012 (may work on previous versions)
 
 ## Recipes
 
@@ -49,12 +50,14 @@ The service recipe enables the runit service for minecraft.
 
 * `minecraft['group']`
   - The group the minecraft server runs under, default `mcserver`
+  - Not applicable to windows
 
 * `minecraft['install_dir']`
-  - The default location minecraft is installed to, default `/srv/minecraft`
+  - The default location minecraft is installed to, default `/srv/minecraft` (`%ProgramData%\minecraft` on windows)
 
 * `minecraft['install_type']`
   - Supports 'vanilla' and 'bukkit', default 'vanilla'
+  - Only 'vanilla' is currently supported on windows
 
 * `minecraft['url']`
   - The url to fetch minecarft releases from, default `https://s3.amazonaws.com/Minecraft.Download/versions`
@@ -72,7 +75,7 @@ The service recipe enables the runit service for minecraft.
   - You can use this to pass additional options to java, default blank
 
 * `minecraft['init_style']`
-  - Currently only runit is support. default `runit`
+  - Currently only `runit` is support on linux and `windows_task` on windows
 
 * `minecraft['banned-ips']`
   - An array of ips you would like banned, default blank

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,19 +19,20 @@
 
 default['minecraft']['user']                = 'mcserver'
 default['minecraft']['group']               = 'mcserver'
-default['minecraft']['install_dir']         = '/srv/minecraft'
 # Currently vanilla, bukkit, spigot
 default['minecraft']['install_type']        = 'vanilla'
 
-default['java']['install_flavor']           = 'default'
+default['java']['install_flavor']           = 'openjdk'
 
 case node['minecraft']['install_type']
 when 'vanilla'
-  default['minecraft']['url']                 = 'https://s3.amazonaws.com/Minecraft.Download/versions/1.8.1/minecraft_server.1.8.1.jar'
+  default['minecraft']['version']             = '1.8.1'
+  default['minecraft']['url']                 = "https://s3.amazonaws.com/Minecraft.Download/versions/#{node['minecraft']['version']}/minecraft_server.#{node['minecraft']['version']}.jar"
   default['minecraft']['checksum']            = 'ef5f5a1a1a78087859b18153acf97efc6ecb12540ac08d82b9c95024249b9845'
   default['minecraft']['server_opts']         = 'nogui'
 when 'bukkit'
-  default['minecraft']['url']                 = 'http://dl.bukkit.org/downloads/craftbukkit/get/02389_1.6.4-R2.0/craftbukkit.jar'
+  default['minecraft']['version']             = '1.6.4'
+  default['minecraft']['url']                 = "http://dl.bukkit.org/downloads/craftbukkit/get/02389_#{node['minecraft']['version']}-R2.0/craftbukkit.jar"
   default['minecraft']['checksum']            = '29c26ec69dcaf8c1214f90f5fa5609fc451aae5fe0d22fd4ce37a505684545b3'
   default['minecraft']['server_opts']         = '--noconsole --online-mode true'
 when 'spigot'
@@ -41,21 +42,29 @@ when 'spigot'
 end
 
 # Defaults to 40% of your total memory.
-default['minecraft']['xms']                 = "#{(node['memory']['total'].to_i * 0.4).floor / 1024}M"
+default['minecraft']['xms']                 = "#{(total_memory * 0.4).floor / 1024}M"
 # Defaults to 60% of your total memory.
-default['minecraft']['xmx']                 = "#{(node['memory']['total'].to_i * 0.6).floor / 1024}M"
+default['minecraft']['xmx']                 = "#{(total_memory * 0.6).floor / 1024}M"
 
 # Additional options to be passed to java, for runit only
 default['minecraft']['java-options']        = ''
-default['minecraft']['init_style']          = 'runit'
 
-default['minecraft']['ops']                 = []
-default['minecraft']['banned-ips']          = []
-default['minecraft']['banned-players']      = []
-default['minecraft']['white-list']          = []
+minecraft_server_files.each do |file|
+  default['minecraft'][file]                 = []
+end
 
 # Stop minecraft from binding to ipv6 by default
 default['minecraft']['prefer_ipv4'] = true
 
 # See the readme for an explanation
 default['minecraft']['autorestart'] = true
+
+case node['platform_family']
+when 'windows'
+  default['minecraft']['init_style']          = 'windows_task'
+  default['minecraft']['install_dir']         = "#{ENV['programdata']}/minecraft"
+  default['minecraft']['user_password']       = 'Pass@word1'
+else
+  default['minecraft']['init_style']          = 'runit'
+  default['minecraft']['install_dir']         = '/srv/minecraft'
+end

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,99 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+*.vhd
+*.vhdxb
+
+# Travis #
+##########
+.travis.yml
+
+.kitchen

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -4,35 +4,39 @@ require 'minitest/spec'
 ## Spec:: default
 
 describe_recipe 'minecraft::default' do
+  let(:is_windows) { node['platform_family'] == 'windows' }
+
   describe 'ensures the install directory is present' do
     let(:dir) { directory(node['minecraft']['install_dir']) }
-    it { dir.must_have(:mode, '0755') }
-    it { dir.must_have(:owner, node['minecraft']['user']) }
-    it { dir.must_have(:group, node['minecraft']['group']) }
+    it { dir.must_exist }
+    it { dir.must_have(:mode, '0755') unless is_windows }
+    it { dir.must_have(:owner, node['minecraft']['user']) unless is_windows }
+    it { dir.must_have(:group, node['minecraft']['group']) unless is_windows }
   end
 
   describe 'ensures minecraft jar exists' do
     let(:jar) { file("#{node['minecraft']['install_dir']}/#{minecraft_file(node['minecraft']['url'])}") }
-    it { jar.must_have(:mode, '0644') }
-    it { jar.must_have(:owner, node['minecraft']['user']) }
-    it { jar.must_have(:group, node['minecraft']['group']) }
+    it { jar.must_exist }
+    it { jar.must_have(:mode, '0644') unless is_windows }
+    it { jar.must_have(:owner, node['minecraft']['user']) unless is_windows }
+    it { jar.must_have(:group, node['minecraft']['group']) unless is_windows }
   end
 
   describe 'ensures server.properties is present' do
     let(:config) { file("#{node['minecraft']['install_dir']}/server.properties") }
-    it { config.must_have(:mode, '0644') }
-    it { config.must_have(:owner, node['minecraft']['user']) }
-    it { config.must_have(:group, node['minecraft']['group']) }
-  end
-
-  describe 'ensures the install directory is present' do
-    let(:dir) { directory(node['minecraft']['install_dir']) }
-    it { dir.must_have(:mode, '0755') }
-    it { dir.must_have(:owner, node['minecraft']['user']) }
-    it { dir.must_have(:group, node['minecraft']['group']) }
+    it { config.must_exist }
+    it { config.must_have(:mode, '0644') unless is_windows }
+    it { config.must_have(:owner, node['minecraft']['user']) unless is_windows }
+    it { config.must_have(:group, node['minecraft']['group']) unless is_windows }
   end
 
   it 'ensures minecraft is running' do
-    service('minecraft').must_be_running
+    service('minecraft').must_be_running unless is_windows
+    if is_windows
+      wmi = ::WIN32OLE.connect('winmgmts://')
+      jar_path = minecraft_file(node['minecraft']['url'])
+      proc = wmi.ExecQuery("select ProcessId from Win32_Process where name = 'java.exe' and CommandLine like '%#{jar_path}%'")
+      proc.each.count.must_be :==, 1
+    end
   end
 end

--- a/files/default/tests/minitest/user_test.rb
+++ b/files/default/tests/minitest/user_test.rb
@@ -4,8 +4,10 @@ require 'minitest/spec'
 ## Spec:: user
 
 describe_recipe 'minecraft::user' do
+  let(:is_windows) { node['platform_family'] == 'windows' }
+
   it 'ensures minecraft group exists' do
-    group(node['minecraft']['group']).must_exist
+    group(node['minecraft']['group']).must_exist unless is_windows
   end
 
   it 'ensures minecraft user exists' do

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,8 +16,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+def minecraft_file_format
+  uses_json ? 'json' : 'txt'
+end
+
+def minecraft_server_files
+  if uses_json
+    %w(ops banned-ips banned-players whitelist)
+  else
+    %w(ops banned-ips banned-players white-list)
+  end
+end
+
+def uses_json
+  node['minecraft']['version'] && node['minecraft']['version'] >= '1.7.9'
+end
+
 def minecraft_file(uri)
   require 'pathname'
   require 'uri'
   Pathname.new(URI.parse(uri).path).basename.to_s
+end
+
+def total_memory
+  if node['platform_family'] == 'windows'
+    wmi = ::WIN32OLE.connect('winmgmts://')
+    res = wmi.ExecQuery('select Capacity from Win32_PhysicalMemory')
+    mem = res.each.next.capacity
+    mem.to_i / 1024
+  else
+    node['memory']['total'].to_i
+  end
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,9 @@
+if defined?(ChefSpec)
+  def enable_minecraft_windows_task(task_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:minecraft_windows_task, :enable, task_name)
+  end
+
+  def start_minecraft_windows_task(task_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:minecraft_windows_task, :start, task_name)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,15 +3,15 @@ maintainer_email  'greg@gregf.org'
 license           'Apache 2'
 description       'Installs/Configures minecraft server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.5.2'
+version           '0.6.2'
 name              'minecraft'
 
 recipe 'minecraft', 'Installs and configures minecraft server.'
 
-%w(java runit ohai apt yum).each do |dep|
+%w(java runit ohai apt yum chocolatey windows).each do |dep|
   depends dep
 end
 
-%w(debian ubuntu centos).each do |os|
+%w(debian ubuntu centos windows).each do |os|
   supports os
 end

--- a/providers/windows_task.rb
+++ b/providers/windows_task.rb
@@ -1,0 +1,92 @@
+use_inline_resources
+
+action :enable do
+  batch_path = ::File.join(node['minecraft']['install_dir'], 'minecraft.bat')
+
+  template batch_path do
+    source 'minecraft.bat.erb'
+    owner node['minecraft']['user']
+    action :create
+    variables(
+      :jar => ::File.join(node['minecraft']['install_dir'], minecraft_file(node['minecraft']['url']))
+    )
+  end
+
+  task = windows_task 'minecraft' do
+    user node['minecraft']['user']
+    password node['minecraft']['user_password']
+    cwd node['minecraft']['install_dir']
+    command batch_path
+    frequency :onstart
+  end
+
+  new_resource.updated_by_last_action(task.updated_by_last_action?)
+end
+
+action :start do
+  minecraft_start
+end
+
+action :stop do
+  action_stop
+end
+
+action :restart do
+  minecraft_stop
+  minecraft_start
+end
+
+def minecraft_start
+  pid = find_server_proc_id
+  if pid.nil?
+    converge_by('starting minecraft batch file') do
+      windows_task 'minecraft' do
+        action :run
+      end
+
+      ruby_block 'wait for java' do
+        block do
+          Timeout.timeout(60) do
+            sleep 5 while find_server_proc_id.nil?
+          end
+        end
+      end
+
+      @new_resource.updated_by_last_action(true)
+    end
+  else
+    Chef::Log.info("minecraft already running as pid #{pid}")
+    @new_resource.updated_by_last_action(false)
+  end
+end
+
+def minecraft_stop
+  pid = find_server_proc_id
+
+  if !pid.nil?
+    converge_by("Sending interrupt signal to pid #{pid}") do
+      Process.kill :KILL, pid
+
+      Timeout.timeout(60) do
+        sleep 5 until find_server_proc_id.nil?
+      end
+    end
+    new_resource.updated_by_last_action(true)
+  else
+    Chef::Log.info('no minecraft server to stop')
+    new_resource.updated_by_last_action(false)
+  end
+end
+
+def find_server_proc_id
+  jar_path = minecraft_file(node['minecraft']['url'])
+  Chef::Log.info("searching for process running #{jar_path}")
+
+  res = wmi.ExecQuery("select ProcessId from Win32_Process where name = 'java.exe' and CommandLine like '%#{jar_path}%'")
+  res.each.next.ProcessId if res.each.count > 0
+end
+
+def wmi
+  @wmi ||= ::WIN32OLE.connect('winmgmts://')
+  @wmi
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,11 +17,8 @@
 # limitations under the License.
 #
 
-include_recipe "java::#{node['java']['install_flavor']}"
-include_recipe 'runit'
+include_recipe 'minecraft::java'
 include_recipe 'minecraft::user'
-
-jar_name = minecraft_file(node['minecraft']['url'])
 
 directory node['minecraft']['install_dir'] do
   recursive true
@@ -30,6 +27,8 @@ directory node['minecraft']['install_dir'] do
   mode 0755
   action :create
 end
+
+jar_name = minecraft_file(node['minecraft']['url'])
 
 remote_file "#{node['minecraft']['install_dir']}/#{jar_name}" do
   source node['minecraft']['url']
@@ -48,17 +47,17 @@ template "#{node['minecraft']['install_dir']}/server.properties" do
   group node['minecraft']['group']
   mode 0644
   action :create
-  notifies :restart, 'runit_service[minecraft]', :delayed if node['minecraft']['autorestart']
+  notifies :restart, node['minecraft']['notify_resource'], :delayed if node['minecraft']['autorestart']
 end
 
-%w(ops banned-ips banned-players white-list).each do |f|
-  file "#{node['minecraft']['install_dir']}/#{f}.txt" do
+minecraft_server_files.each do |f|
+  file "#{node['minecraft']['install_dir']}/#{f}.#{minecraft_file_format}" do
     owner node['minecraft']['user']
     group node['minecraft']['group']
     mode 0644
     action :create
     content node['minecraft'][f].join("\n") + "\n"
-    notifies :restart, 'runit_service[minecraft]', :delayed if node['minecraft']['autorestart']
+    notifies :restart, node['minecraft']['notify_resource'], :delayed if node['minecraft']['autorestart']
   end
 end
 
@@ -66,5 +65,5 @@ file "#{node['minecraft']['install_dir']}/eula.txt" do
   content "eula=#{node['minecraft']['accept_eula']}\n"
   mode 0644
   action :create
-  notifies :restart, 'runit_service[minecraft]', :delayed if node['minecraft']['autorestart']
+  notifies :restart, node['minecraft']['notify_resource'], :delayed if node['minecraft']['autorestart']
 end

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -1,0 +1,7 @@
+case node['platform_family']
+when 'windows'
+  include_recipe 'chocolatey'
+  chocolatey 'javaruntime'
+else
+  include_recipe 'java'
+end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -20,6 +20,8 @@
 
 case node['minecraft']['init_style']
 when 'runit'
+  include_recipe 'runit'
+  node.default['minecraft']['notify_resource'] = 'runit_service[minecraft]'
   runit_service 'minecraft' do
     options({
       :install_dir => node['minecraft']['install_dir'],
@@ -32,6 +34,12 @@ when 'runit'
       :server_opts => node['minecraft']['server_opts'],
       :jar_name    => minecraft_file(node['minecraft']['url'])
     }.merge(params))
+    action [:enable, :start]
+  end
+when 'windows_task'
+  node.default['minecraft']['notify_resource'] = 'minecraft_windows_task[minecraft]'
+
+  minecraft_windows_task 'minecraft' do
     action [:enable, :start]
   end
 end

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -17,13 +17,32 @@
 # limitations under the License.
 #
 
-group node['minecraft']['group']
+group node['minecraft']['group'] unless node['platform_family'] == 'windows'
 
 user node['minecraft']['user'] do
   system true
   comment 'Minecraft Server'
   home node['minecraft']['install_dir']
-  gid node['minecraft']['group']
   shell '/bin/false'
+  if node['minecraft']['user_password']
+    password node['minecraft']['user_password']
+  end
+  gid node['minecraft']['group'] if node['platform_family'] != 'windows'
   action :create
+end
+
+if node['platform_family'] == 'windows'
+  template "#{ENV['temp']}/LsaWrapper.ps1" do
+    source 'LsaWrapper.ps1.erb'
+    owner node['minecraft']['user']
+    action :create
+  end
+
+  powershell_script 'Add Log on as a batch job to mcserver user' do
+    code <<-EOS
+      . #{ENV['temp']}/LsaWrapper.ps1
+      $lsa_wrapper = New-Object -type LsaWrapper
+      $lsa_wrapper.SetRight("#{node['minecraft']['user']}", "SeBatchLogonRight")
+    EOS
+  end
 end

--- a/resources/windows_task.rb
+++ b/resources/windows_task.rb
@@ -1,0 +1,4 @@
+actions :enable, :start, :stop, :restart
+default_action :enable
+
+attribute :service_name, :kind_of => String, :name_attribute => true

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -8,22 +8,43 @@ describe 'minecraft attributes' do
   end
   let(:minecraft) { chef_run.node['minecraft'] }
 
-  describe 'on an debian system' do
-    it 'sets the default user & group' do
-      expect(minecraft['user']).to eq('mcserver')
-      expect(minecraft['group']).to eq('mcserver')
+  it 'sets the default user & group' do
+    expect(minecraft['user']).to eq('mcserver')
+    expect(minecraft['group']).to eq('mcserver')
+  end
+
+  it 'has a url' do
+    expect(minecraft['url']).to match(/http.+minecraft_server.\d.\d.\d.jar/)
+  end
+
+  it 'has contains a valid checksum' do
+    expect(minecraft['checksum']).to match(/\b(?:[a-fA-F0-9][\r\n]*){64}\b/)
+  end
+
+  it 'sets java-options to be a empty string' do
+    expect(minecraft['java-options']).to eq('')
+  end
+
+  it 'sets some empty arrays for configuration files' do
+    expect(minecraft['ops']).to eq([])
+    expect(minecraft['banned-ips']).to eq([])
+    expect(minecraft['banned-players']).to eq([])
+    expect(minecraft['whitelist']).to eq([])
+  end
+
+  it 'sets autorestart to true' do
+    expect(minecraft['autorestart']).to eq(true)
+  end
+
+  context 'on an debian system' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0') do |node|
+        node.automatic['memory']['total'] = '2097152kB'
+      end.converge('minecraft::default')
     end
 
     it 'sets a installation directory' do
       expect(minecraft['install_dir']).to eq('/srv/minecraft')
-    end
-
-    it 'has a url' do
-      expect(minecraft['url']).to match(/http.+minecraft_server.\d.\d.\d.jar/)
-    end
-
-    it 'has contains a valid checksum' do
-      expect(minecraft['checksum']).to match(/\b(?:[a-fA-F0-9][\r\n]*){64}\b/)
     end
 
     it 'sets some default options for java' do
@@ -31,23 +52,41 @@ describe 'minecraft attributes' do
       expect(minecraft['xmx']).to eq('1228M')
     end
 
-    it 'sets java-options to be a empty string' do
-      expect(minecraft['java-options']).to eq('')
-    end
-
     it 'sets default init_style to be runit' do
       expect(minecraft['init_style']).to eq('runit')
     end
+  end
 
-    it 'sets some empty arrays for configuration files' do
-      expect(minecraft['ops']).to eq([])
-      expect(minecraft['banned-ips']).to eq([])
-      expect(minecraft['banned-players']).to eq([])
-      expect(minecraft['white-list']).to eq([])
+  context 'on a windows system' do
+    let(:chef_run) { ChefSpec::Runner.new(:platform => 'windows', :version  => '2008R2').converge('minecraft::default') }
+    let(:memory) { double('win32_memory', :capacity => 2_097_152 * 1_024) }
+    let(:wmi) { double('wmi', :ExecQuery => [memory]) }
+    before do
+      begin
+        require 'win32ole'
+      rescue LoadError
+        class WIN32OLE
+        end
+      end
+
+      allow(WIN32OLE).to receive(:connect).with('winmgmts://').and_return(wmi)
     end
 
-    it 'sets autorestart to true' do
-      expect(minecraft['autorestart']).to eq(true)
+    it 'sets a installation directory' do
+      expect(minecraft['install_dir']).to eq("#{ENV['programdata']}/minecraft")
+    end
+
+    it 'sets the default user password' do
+      expect(minecraft['user_password']).to eq('Pass@word1')
+    end
+
+    it 'sets the default init style' do
+      expect(minecraft['init_style']).to eq('windows_task')
+    end
+
+    it 'sets some default options for java' do
+      expect(minecraft['xms']).to eq('819M')
+      expect(minecraft['xmx']).to eq('1228M')
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,17 +4,20 @@ describe 'minecraft::default' do
   context 'install minecraft defaults' do
     let(:chef_run) do
       ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0') do |node|
+        node.set['minecraft']['version'] = minecraft_version
         node.set['minecraft']['ops'] = %w(gregf sandal82)
         node.set['minecraft']['banned-ips'] = %w(10.1.2.3 10.1.100.10)
         node.set['minecraft']['banned-players'] = %w(gregf sandal82)
         node.set['minecraft']['white-list'] = %w(gregf sandal82)
+        node.set['minecraft']['whitelist'] = %w(gregf sandal82)
         node.automatic['memory']['total'] = '2097152kB'
       end.converge(described_recipe)
     end
+    let(:minecraft_version) { '1.8.1' }
     let(:minecraft_jar) { '/srv/minecraft/minecraft_server.1.8.1.jar' }
 
-    it 'includes default java recipe' do
-      expect(chef_run).to include_recipe('java::default')
+    it 'includes java recipe' do
+      expect(chef_run).to include_recipe('minecraft::java')
     end
 
     it 'includes the minecraft::user recipe' do
@@ -55,77 +58,152 @@ describe 'minecraft::default' do
       end
     end
 
-    context 'creates ops.txt' do
-      let(:ops) { chef_run.file('/srv/minecraft/ops.txt') }
+    context 'minecraft_server version 1.7.2' do
+      let(:minecraft_version) { '1.7.2' }
 
-      it 'creates ops.txt' do
-        expect(chef_run).to create_file(ops.path).with_content("gregf\nsandal82\n")
+      context 'creates ops.txt' do
+        let(:ops) { chef_run.file('/srv/minecraft/ops.txt') }
+
+        it 'creates ops.txt' do
+          expect(chef_run).to create_file(ops.path).with_content("gregf\nsandal82\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(ops.owner).to eq('mcserver')
+          expect(ops.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(ops.mode).to eq(0644)
+        end
       end
 
-      it 'is owned by mcserver:mcserver' do
-        expect(ops.owner).to eq('mcserver')
-        expect(ops.group).to eq('mcserver')
+      context 'creates banned-ips.txt' do
+        let(:banned_ips) { chef_run.file('/srv/minecraft/banned-ips.txt') }
+
+        it 'creates banned-ips.txt' do
+          expect(chef_run).to create_file(banned_ips.path).with_content("10.1.2.3\n10.1.100.10\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(banned_ips.owner).to eq('mcserver')
+          expect(banned_ips.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(banned_ips.mode).to eq(0644)
+        end
       end
 
-      it 'has 0644 permissions' do
-        expect(ops.mode).to eq(0644)
+      context 'creates banned-players.txt' do
+        let(:banned_players) { chef_run.file('/srv/minecraft/banned-players.txt') }
+
+        it 'creates banned-ips.txt' do
+          expect(chef_run).to create_file(banned_players.path).with_content("gregf\nsandal82\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(banned_players.owner).to eq('mcserver')
+          expect(banned_players.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(banned_players.mode).to eq(0644)
+        end
+      end
+
+      context 'creates white-list.txt' do
+        let(:white_list) { chef_run.file('/srv/minecraft/white-list.txt') }
+
+        it 'creates banned-ips.txt' do
+          expect(chef_run).to create_file(white_list.path).with_content("gregf\nsandal82\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(white_list.owner).to eq('mcserver')
+          expect(white_list.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(white_list.mode).to eq(0644)
+        end
       end
     end
 
-    context 'creates banned-ips.txt' do
-      let(:banned_ips) { chef_run.file('/srv/minecraft/banned-ips.txt') }
+    context 'minecraft_server version 1.8.1' do
+      let(:minecraft_version) { '1.8.1' }
 
-      it 'creates banned-ips.txt' do
-        expect(chef_run).to create_file(banned_ips.path).with_content("10.1.2.3\n10.1.100.10\n")
+      context 'creates ops.json' do
+        let(:ops) { chef_run.file('/srv/minecraft/ops.json') }
+
+        it 'creates ops.json' do
+          expect(chef_run).to create_file(ops.path).with_content("gregf\nsandal82\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(ops.owner).to eq('mcserver')
+          expect(ops.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(ops.mode).to eq(0644)
+        end
       end
 
-      it 'is owned by mcserver:mcserver' do
-        expect(banned_ips.owner).to eq('mcserver')
-        expect(banned_ips.group).to eq('mcserver')
+      context 'creates banned-ips.json' do
+        let(:banned_ips) { chef_run.file('/srv/minecraft/banned-ips.json') }
+
+        it 'creates banned-ips.json' do
+          expect(chef_run).to create_file(banned_ips.path).with_content("10.1.2.3\n10.1.100.10\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(banned_ips.owner).to eq('mcserver')
+          expect(banned_ips.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(banned_ips.mode).to eq(0644)
+        end
       end
 
-      it 'has 0644 permissions' do
-        expect(banned_ips.mode).to eq(0644)
-      end
-    end
+      context 'creates banned-players.json' do
+        let(:banned_players) { chef_run.file('/srv/minecraft/banned-players.json') }
 
-    context 'creates banned-players.txt' do
-      let(:banned_players) { chef_run.file('/srv/minecraft/banned-players.txt') }
+        it 'creates banned-ips.json' do
+          expect(chef_run).to create_file(banned_players.path).with_content("gregf\nsandal82\n")
+        end
 
-      it 'creates banned-ips.txt' do
-        expect(chef_run).to create_file(banned_players.path).with_content("gregf\nsandal82\n")
-      end
+        it 'is owned by mcserver:mcserver' do
+          expect(banned_players.owner).to eq('mcserver')
+          expect(banned_players.group).to eq('mcserver')
+        end
 
-      it 'is owned by mcserver:mcserver' do
-        expect(banned_players.owner).to eq('mcserver')
-        expect(banned_players.group).to eq('mcserver')
-      end
-
-      it 'has 0644 permissions' do
-        expect(banned_players.mode).to eq(0644)
-      end
-    end
-
-    context 'creates white-list.txt' do
-      let(:white_list) { chef_run.file('/srv/minecraft/white-list.txt') }
-
-      it 'creates banned-ips.txt' do
-        expect(chef_run).to create_file(white_list.path).with_content("gregf\nsandal82\n")
+        it 'has 0644 permissions' do
+          expect(banned_players.mode).to eq(0644)
+        end
       end
 
-      it 'is owned by mcserver:mcserver' do
-        expect(white_list.owner).to eq('mcserver')
-        expect(white_list.group).to eq('mcserver')
-      end
+      context 'creates whitelist.json' do
+        let(:whitelist) { chef_run.file('/srv/minecraft/whitelist.json') }
 
-      it 'has 0644 permissions' do
-        expect(white_list.mode).to eq(0644)
+        it 'creates whitelist.json' do
+          expect(chef_run).to create_file(whitelist.path).with_content("gregf\nsandal82\n")
+        end
+
+        it 'is owned by mcserver:mcserver' do
+          expect(whitelist.owner).to eq('mcserver')
+          expect(whitelist.group).to eq('mcserver')
+        end
+
+        it 'has 0644 permissions' do
+          expect(whitelist.mode).to eq(0644)
+        end
       end
     end
 
     it 'includes the minecraft::service recipe' do
       expect(chef_run).to include_recipe('minecraft::service')
-      expect(chef_run).to include_recipe('runit')
     end
   end
 end

--- a/spec/unit/recipes/java_spec.rb
+++ b/spec/unit/recipes/java_spec.rb
@@ -1,24 +1,19 @@
 require 'spec_helper'
 
-describe 'minecraft::user' do
-  context 'creates a debian user for the minecraft server' do
+describe 'minecraft::java' do
+  context 'installs java on debian' do
     let(:chef_run) do
       ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0') do |node|
         node.automatic['memory']['total'] = '2097152kB'
       end.converge(described_recipe)
     end
 
-    it 'creates a user with attributes' do
-      expect(chef_run).to create_user('mcserver').with(
-        shell: '/bin/false',
-        gid: 'mcserver',
-        home: '/srv/minecraft',
-        password: nil
-      )
+    it 'includes the default java recipe' do
+      expect(chef_run).to include_recipe('java::default')
     end
   end
 
-  context 'creates a windows user for the minecraft server' do
+  context 'intalls java via chocolatey on windows' do
     let(:chef_run) { ChefSpec::Runner.new(:platform => 'windows', :version  => '2008R2').converge('minecraft::default') }
     let(:memory) { double('win32_memory', :capacity => 2_097_152 * 1_024) }
     let(:wmi) { double('wmi', :ExecQuery => [memory]) }
@@ -33,17 +28,8 @@ describe 'minecraft::user' do
       allow(WIN32OLE).to receive(:connect).with('winmgmts://').and_return(wmi)
     end
 
-    it 'creates a user with password and no group' do
-      expect(chef_run).to create_user('mcserver').with(
-        shell: '/bin/false',
-        gid: nil,
-        password: 'Pass@word1',
-        home: '/minecraft'
-      )
-    end
-
-    it 'renders the win api ps template' do
-      expect(chef_run).to render_file("#{ENV['temp']}/LsaWrapper.ps1")
+    it 'includes the default chocolatey recipe' do
+      expect(chef_run).to include_recipe('chocolatey::default')
     end
   end
 end

--- a/spec/unit/recipes/service_spec.rb
+++ b/spec/unit/recipes/service_spec.rb
@@ -1,14 +1,39 @@
 require 'spec_helper'
 
 describe 'minecraft::service' do
-  context 'starts the minecraft service' do
-    let(:chef_run) { ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0').converge(described_recipe) }
+  context 'starts the minecraft service on with runit' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0') do |node|
+        node.set['minecraft']['init_style'] = 'runit'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the runit recipe' do
+      expect(chef_run).to include_recipe('runit')
+    end
+
     it 'enables the service' do
       expect(chef_run).to enable_runit_service('minecraft')
     end
 
-    it 'starts the service' do
+    it 'starts the runit service' do
       expect(chef_run).to start_runit_service('minecraft')
+    end
+  end
+
+  context 'starts the minecraft service with windows task' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(:platform => 'debian', :version  => '7.0') do |node|
+        node.set['minecraft']['init_style'] = 'windows_task'
+      end.converge(described_recipe)
+    end
+
+    it 'enables the windows_task' do
+      expect(chef_run).to enable_minecraft_windows_task('minecraft')
+    end
+
+    it 'starts the windows task' do
+      expect(chef_run).to start_minecraft_windows_task('minecraft')
     end
   end
 end

--- a/templates/default/LsaWrapper.ps1.erb
+++ b/templates/default/LsaWrapper.ps1.erb
@@ -1,0 +1,192 @@
+$wrapper = @'
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public class LsaWrapper
+{
+// Import the LSA functions
+ 
+[DllImport("advapi32.dll", PreserveSig = true)]
+private static extern UInt32 LsaOpenPolicy(
+    ref LSA_UNICODE_STRING SystemName,
+    ref LSA_OBJECT_ATTRIBUTES ObjectAttributes,
+    Int32 DesiredAccess,
+    out IntPtr PolicyHandle
+    );
+ 
+[DllImport("advapi32.dll", SetLastError = true, PreserveSig = true)]
+private static extern long LsaAddAccountRights(
+    IntPtr PolicyHandle,
+    IntPtr AccountSid,
+    LSA_UNICODE_STRING[] UserRights,
+    long CountOfRights);
+ 
+[DllImport("advapi32")]
+public static extern void FreeSid(IntPtr pSid);
+ 
+[DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = true)]
+private static extern bool LookupAccountName(
+    string lpSystemName, string lpAccountName,
+    IntPtr psid,
+    ref int cbsid,
+    StringBuilder domainName, ref int cbdomainLength, ref int use);
+ 
+[DllImport("advapi32.dll")]
+private static extern bool IsValidSid(IntPtr pSid);
+ 
+[DllImport("advapi32.dll")]
+private static extern long LsaClose(IntPtr ObjectHandle);
+ 
+[DllImport("kernel32.dll")]
+private static extern int GetLastError();
+ 
+[DllImport("advapi32.dll")]
+private static extern long LsaNtStatusToWinError(long status);
+ 
+// define the structures
+ 
+private enum LSA_AccessPolicy : long
+{
+    POLICY_VIEW_LOCAL_INFORMATION = 0x00000001L,
+    POLICY_VIEW_AUDIT_INFORMATION = 0x00000002L,
+    POLICY_GET_PRIVATE_INFORMATION = 0x00000004L,
+    POLICY_TRUST_ADMIN = 0x00000008L,
+    POLICY_CREATE_ACCOUNT = 0x00000010L,
+    POLICY_CREATE_SECRET = 0x00000020L,
+    POLICY_CREATE_PRIVILEGE = 0x00000040L,
+    POLICY_SET_DEFAULT_QUOTA_LIMITS = 0x00000080L,
+    POLICY_SET_AUDIT_REQUIREMENTS = 0x00000100L,
+    POLICY_AUDIT_LOG_ADMIN = 0x00000200L,
+    POLICY_SERVER_ADMIN = 0x00000400L,
+    POLICY_LOOKUP_NAMES = 0x00000800L,
+    POLICY_NOTIFICATION = 0x00001000L
+}
+ 
+[StructLayout(LayoutKind.Sequential)]
+private struct LSA_OBJECT_ATTRIBUTES
+{
+    public int Length;
+    public IntPtr RootDirectory;
+    public readonly LSA_UNICODE_STRING ObjectName;
+    public UInt32 Attributes;
+    public IntPtr SecurityDescriptor;
+    public IntPtr SecurityQualityOfService;
+}
+ 
+[StructLayout(LayoutKind.Sequential)]
+private struct LSA_UNICODE_STRING
+{
+    public UInt16 Length;
+    public UInt16 MaximumLength;
+    public IntPtr Buffer;
+}
+/// 
+//Adds a privilege to an account
+ 
+/// Name of an account - "domain\account" or only "account"
+/// Name ofthe privilege
+/// The windows error code returned by LsaAddAccountRights
+public long SetRight(String accountName, String privilegeName)
+{
+    long winErrorCode = 0; //contains the last error
+ 
+    //pointer an size for the SID
+    IntPtr sid = IntPtr.Zero;
+    int sidSize = 0;
+    //StringBuilder and size for the domain name
+    var domainName = new StringBuilder();
+    int nameSize = 0;
+    //account-type variable for lookup
+    int accountType = 0;
+ 
+    //get required buffer size
+    LookupAccountName(String.Empty, accountName, sid, ref sidSize, domainName, ref nameSize, ref accountType);
+ 
+    //allocate buffers
+    domainName = new StringBuilder(nameSize);
+    sid = Marshal.AllocHGlobal(sidSize);
+ 
+    //lookup the SID for the account
+    bool result = LookupAccountName(String.Empty, accountName, sid, ref sidSize, domainName, ref nameSize,
+                                    ref accountType);
+ 
+    //say what you're doing
+    Console.WriteLine("LookupAccountName result = " + result);
+    Console.WriteLine("IsValidSid: " + IsValidSid(sid));
+    Console.WriteLine("LookupAccountName domainName: " + domainName);
+ 
+    if (!result)
+    {
+        winErrorCode = GetLastError();
+        Console.WriteLine("LookupAccountName failed: " + winErrorCode);
+    }
+    else
+    {
+        //initialize an empty unicode-string
+        var systemName = new LSA_UNICODE_STRING();
+        //combine all policies
+        var access = (int) (
+                                LSA_AccessPolicy.POLICY_AUDIT_LOG_ADMIN |
+                                LSA_AccessPolicy.POLICY_CREATE_ACCOUNT |
+                                LSA_AccessPolicy.POLICY_CREATE_PRIVILEGE |
+                                LSA_AccessPolicy.POLICY_CREATE_SECRET |
+                                LSA_AccessPolicy.POLICY_GET_PRIVATE_INFORMATION |
+                                LSA_AccessPolicy.POLICY_LOOKUP_NAMES |
+                                LSA_AccessPolicy.POLICY_NOTIFICATION |
+                                LSA_AccessPolicy.POLICY_SERVER_ADMIN |
+                                LSA_AccessPolicy.POLICY_SET_AUDIT_REQUIREMENTS |
+                                LSA_AccessPolicy.POLICY_SET_DEFAULT_QUOTA_LIMITS |
+                                LSA_AccessPolicy.POLICY_TRUST_ADMIN |
+                                LSA_AccessPolicy.POLICY_VIEW_AUDIT_INFORMATION |
+                                LSA_AccessPolicy.POLICY_VIEW_LOCAL_INFORMATION
+                            );
+        //initialize a pointer for the policy handle
+        IntPtr policyHandle = IntPtr.Zero;
+ 
+        //these attributes are not used, but LsaOpenPolicy wants them to exists
+        var ObjectAttributes = new LSA_OBJECT_ATTRIBUTES();
+        ObjectAttributes.Length = 0;
+        ObjectAttributes.RootDirectory = IntPtr.Zero;
+        ObjectAttributes.Attributes = 0;
+        ObjectAttributes.SecurityDescriptor = IntPtr.Zero;
+        ObjectAttributes.SecurityQualityOfService = IntPtr.Zero;
+ 
+        //get a policy handle
+        uint resultPolicy = LsaOpenPolicy(ref systemName, ref ObjectAttributes, access, out policyHandle);
+        winErrorCode = LsaNtStatusToWinError(resultPolicy);
+ 
+        if (winErrorCode != 0)
+        {
+            Console.WriteLine("OpenPolicy failed: " + winErrorCode);
+        }
+        else
+        {
+            //Now that we have the SID an the policy,
+            //we can add rights to the account.
+ 
+            //initialize an unicode-string for the privilege name
+            var userRights = new LSA_UNICODE_STRING[1];
+            userRights[0] = new LSA_UNICODE_STRING();
+            userRights[0].Buffer = Marshal.StringToHGlobalUni(privilegeName);
+            userRights[0].Length = (UInt16) (privilegeName.Length*UnicodeEncoding.CharSize);
+            userRights[0].MaximumLength = (UInt16) ((privilegeName.Length + 1)*UnicodeEncoding.CharSize);
+ 
+            //add the right to the account
+            long res = LsaAddAccountRights(policyHandle, sid, userRights, 1);
+            winErrorCode = LsaNtStatusToWinError(res);
+            if (winErrorCode != 0)
+            {
+                Console.WriteLine("LsaAddAccountRights failed: " + winErrorCode);
+            }
+ 
+            LsaClose(policyHandle);
+        }
+        FreeSid(sid);
+    }
+ 
+    return winErrorCode;
+}
+}
+'@
+ 
+Add-Type $wrapper -PassThru

--- a/templates/default/minecraft.bat.erb
+++ b/templates/default/minecraft.bat.erb
@@ -1,0 +1,2 @@
+cd "<%= node['minecraft']['install_dir'] %>"
+cmd /c "%JAVA_HOME%\bin\java.exe" -Xmx<%= node['minecraft']['xmx'] %> -Xms<%= node['minecraft']['xms'] %> -jar <%= @jar %> <%= node['minecraft']['server_opts'] %>


### PR DESCRIPTION
My apologies for this fairly large PR.

This adds windows support for the minecraft server. This adds another possible `init-style` of `windows_task` which is the default and only supported init-style on windows. It creates a windows task named minecraft that is invoked on system startup by the `mcserver` user. The cookbook run will also start the task. 

Since the java cookbook does not support windows at this time, java is installed using chocolatey when run on windows.

**A few notes on implementation**
- I changed the default `['java']['install_flavor']` to `openjdk` because `default` is not a supported value and java was not being installed when I tested this on ubuntu. Perhaps `default` was once supported in the past.
- Minecraft server versions 1.7.9 and forward changed the whitelist and banned file formats to json. I received errors when attempting to start the server with the text files so I added logic to create json files on later minecraft server versions. This works with empty files but I did not convert the text content to json so that is something that should be addressed later. However, my experience was that the current cookbook code did not work at all on later versions (at least 1.8.1).
- I added a .chefignore because I did some testing using Hyper-V and the vhd file is saved in the `.kitchen` directory. So the Berkshelf vendoring was trying to copy the entire vhd to the test instance.
- I added the `.kitchen` folder to the rubocop ignore list so that it did not produce style complaints regarding any `Vagrantfile` there.
- I added a `.kitchen-vagrant.yml` file that only contains tests for `ubuntu 12.04` and `windows 2012 R2`. The windows box is a publically accesible eval version I support. That box currently has an issue with installing the chef client and it may need to be installed manually. I need to update the box with a windows update patch to fix that.