### PR TITLE
Update version & service fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,8 @@ default['minecraft']['user']                = 'mcserver'
 default['minecraft']['group']               = 'mcserver'
 default['minecraft']['install_dir']         = '/srv/minecraft'
 
-default['minecraft']['url']                 = 'https://s3.amazonaws.com/Minecraft.Download/versions/1.8.8/minecraft_server.1.8.8.jar'
-default['minecraft']['checksum']            = '39aef720dc5309476f56f2e96a516f3dd3041bbbf442cbfd47d63acbd06af31e'
+default['minecraft']['url']                 = 'https://s3.amazonaws.com/Minecraft.Download/versions/1.9.4/minecraft_server.1.9.4.jar'
+default['minecraft']['checksum']            = '13fea7aa10d804dd14ed7ebde2493dc64c7d3c8173369309bd7f6ea4c0ea40ad'
 default['minecraft']['server_opts']         = 'nogui'
 
 # Defaults to 40% of your total memory.

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -21,7 +21,9 @@
 case node['minecraft']['init_style']
 when 'runit'
   runit_service 'minecraft' do
-    sv_bin 'sleep 5 && /usr/bin/sv'
+    if File.exists?('/usr/bin/sv')
+      sv_bin 'sleep 5 && /usr/bin/sv'
+    end
     options({
       :install_dir => node['minecraft']['install_dir'],
       :xms         => node['minecraft']['xms'],

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -11,7 +11,7 @@ describe 'minecraft::default' do
         node.automatic['memory']['total'] = '2097152kB'
       end.converge(described_recipe)
     end
-    let(:minecraft_jar) { '/srv/minecraft/minecraft_server.1.8.8.jar' }
+    let(:minecraft_jar) { '/srv/minecraft/minecraft_server.1.9.4.jar' }
 
     it 'includes default java recipe' do
       expect(chef_run).to include_recipe('java::default')

--- a/test/integration/default/serverspec/spec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/spec/localhost/default_spec.rb
@@ -14,7 +14,7 @@ describe file('/srv/minecraft') do
   it { should be_owned_by 'mcserver' }
 end
 
-describe file('/srv/minecraft/minecraft_server.1.8.8.jar') do
+describe file('/srv/minecraft/minecraft_server.1.9.4.jar') do
   it { should be_file }
   it { should be_mode 644 }
   it { should be_owned_by 'mcserver' }


### PR DESCRIPTION
*  Update to 1.9.4.
*  Only set "sv_bin" to 'sleep 5 && /usr/bin/sv' if /usr/bin/sv actually exists.  I'm running on an AWS Linux distro on EC2 & /usr/bin/sv doesn't exist.  This caused service failure.